### PR TITLE
Add wait for vault init container

### DIFF
--- a/charts/operator/templates/_helpers.tpl
+++ b/charts/operator/templates/_helpers.tpl
@@ -69,6 +69,25 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Wait until vault is ready
+*/}}
+{{- define "vault-readiness" -}}
+- name: vault-readiness
+  image: "{{ $.Values.initImageBusybox.repository }}:{{ $.Values.initImageBusybox.tag }}"
+  imagePullPolicy: {{ $.Values.initImageBusybox.pullPolicy }}
+  securityContext:
+    runAsUser: 0
+  command:
+    - /bin/sh
+    - -c
+    {{- if $.Values.vaultAddr }}
+    - "until nc -vz -w 2 {{ $.Values.vaultAddr | replace ":8200" "" |  replace "http://" "" | replace "https://" "" }} 8200; do echo 'Waiting vault'; sleep 2; done"
+    {{- else }}
+    - "until nc -vz -w 2 {{ template "operator.fullname" $ }}-vault 8200; do echo 'Waiting vault'; sleep 2; done"
+    {{- end }}
+{{- end }}
+
+{{/*
 Update permissions on files inside /data directory
 */}}
 {{- define "init-chown" -}}

--- a/charts/operator/templates/statefulset.yaml
+++ b/charts/operator/templates/statefulset.yaml
@@ -43,6 +43,7 @@ spec:
       serviceAccountName: "validator{{.}}"
       priorityClassName: {{ $root.Values.priorityClassName | quote }}
       initContainers:
+        {{- include "vault-readiness" $root | nindent 8 }}
         - name: init-validator
           image: "{{ $root.Values.initImage.repository }}:{{ $root.Values.initImage.tag }}"
           imagePullPolicy: {{ $root.Values.initImage.pullPolicy }}


### PR DESCRIPTION
`vault-readiness` init container is helpful in cases when the vault is unavailable (e.g. GKE preemptible nodes), in this way we can ensure that our validators never go started without keys and get CrashLoopbackOff.