### PR TITLE
fix(charts/erigon): Add POD_IP variable referenced in container command

### DIFF
--- a/charts/erigon/templates/statefulset.yaml
+++ b/charts/erigon/templates/statefulset.yaml
@@ -107,6 +107,12 @@ spec:
               --metrics.addr={{ .Values.metrics.addr }}
               --metrics.port={{ .Values.metrics.port }}
           {{- end }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
           ports:
             - name: grpc
               protocol: TCP


### PR DESCRIPTION
In container there is extip with pod ip set as default, but this variable does not exists:

```yaml
          {{- if .Values.p2pNodePort.enabled }}
              --nat=extip:$EXTERNAL_IP
              --port=$EXTERNAL_PORT
          {{- else }}
              --nat=extip:$(POD_IP)
              --port={{ include "erigon.p2pPort" $ }}
          {{- end }}
```

This PR adds `POD_IP` variable to pod env vars.