### PR TITLE
Add annotations to volumeClaimTemplates of statefulsets

### DIFF
--- a/charts/erigon/templates/statefulset.yaml
+++ b/charts/erigon/templates/statefulset.yaml
@@ -220,6 +220,10 @@ spec:
         name: data
         labels:
           {{- include "common.labels.standard" . | nindent 10 }}
+      {{- with .Values.persistence.annotations }}
+        annotations:
+          {{ toYaml . | nindent 10 | trim }}
+      {{- end }}
       spec:
         accessModes: {{ .Values.persistence.accessModes }}
         storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/erigon/values.yaml
+++ b/charts/erigon/values.yaml
@@ -224,6 +224,7 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 1000Gi
+  annotations: {}
 
 ## Monitoring
 ##

--- a/charts/geth/templates/statefulset.yaml
+++ b/charts/geth/templates/statefulset.yaml
@@ -220,6 +220,10 @@ spec:
         name: data
         labels:
           {{- include "common.labels.matchLabels" . | nindent 10 }}
+      {{- with .Values.persistence.annotations }}
+        annotations:
+          {{ toYaml . | nindent 10 | trim }}
+      {{- end }}
       spec:
         accessModes: {{ .Values.persistence.accessModes }}
         storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/geth/values.yaml
+++ b/charts/geth/values.yaml
@@ -267,6 +267,7 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 900Gi
+  annotations: {}
 
 ## Node labels for pod assignment
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/charts/lighthouse/templates/statefulset.yaml
+++ b/charts/lighthouse/templates/statefulset.yaml
@@ -216,6 +216,10 @@ spec:
         name: data
         labels:
           {{- include "common.labels.standard" . | nindent 10 }}
+      {{- with .Values.persistence.annotations }}
+        annotations:
+          {{ toYaml . | nindent 10 | trim }}
+      {{- end }}
       spec:
         accessModes: {{ .Values.persistence.accessModes }}
         storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -312,3 +312,4 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 250Gi
+  annotations: {}

--- a/charts/nethermind/templates/statefulset.yaml
+++ b/charts/nethermind/templates/statefulset.yaml
@@ -211,6 +211,10 @@ spec:
         name: data
         labels:
           {{- include "common.labels.standard" . | nindent 10 }}
+      {{- with .Values.persistence.annotations }}
+        annotations:
+          {{ toYaml . | nindent 10 | trim }}
+      {{- end }}
       spec:
         accessModes: {{ .Values.persistence.accessModes }}
         storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/nethermind/values.yaml
+++ b/charts/nethermind/values.yaml
@@ -176,6 +176,7 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 250Gi
+  annotations: {}
 
 
 ## Nethermind Settings

--- a/charts/nimbus/templates/statefulset.yaml
+++ b/charts/nimbus/templates/statefulset.yaml
@@ -147,6 +147,10 @@ spec:
         name: data
         labels:
           {{- include "common.labels.standard" . | nindent 10 }}
+      {{- with .Values.persistence.annotations }}
+        annotations:
+          {{ toYaml . | nindent 10 | trim }}
+      {{- end }}
       spec:
         accessModes: {{ .Values.persistence.accessModes }}
         storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/nimbus/values.yaml
+++ b/charts/nimbus/values.yaml
@@ -153,6 +153,7 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 300Gi
+  annotations: {}
 
 
 ## Nimbus: an Ethereum 1.0 and 2.0 Client for Resource-Restricted Devices

--- a/charts/openethereum/templates/statefulset.yaml
+++ b/charts/openethereum/templates/statefulset.yaml
@@ -169,6 +169,10 @@ spec:
         name: data
         labels:
           {{- include "common.labels.standard" . | nindent 10 }}
+      {{- with .Values.persistence.annotations }}
+        annotations:
+          {{ toYaml . | nindent 10 | trim }}
+      {{- end }}
       spec:
         accessModes: {{ .Values.persistence.accessModes }}
         storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/openethereum/values.yaml
+++ b/charts/openethereum/values.yaml
@@ -211,6 +211,7 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 250Gi
+  annotations: {}
 
 ## Node labels for pod assignment
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/charts/prysm/templates/statefulset.yaml
+++ b/charts/prysm/templates/statefulset.yaml
@@ -271,6 +271,10 @@ spec:
         name: data
         labels:
           {{- include "common.labels.standard" . | nindent 10 }}
+      {{- with .Values.persistence.annotations }}
+        annotations:
+          {{ toYaml . | nindent 10 | trim }}
+      {{- end }}
       spec:
         accessModes: {{ .Values.persistence.accessModes }}
         storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/prysm/values.yaml
+++ b/charts/prysm/values.yaml
@@ -319,3 +319,4 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 300Gi
+  annotations: {}

--- a/charts/ssv-node/templates/statefulset.yaml
+++ b/charts/ssv-node/templates/statefulset.yaml
@@ -85,6 +85,10 @@ spec:
         name: data
         labels:
           {{- include "common.labels.standard" . | nindent 10 }}
+      {{- with .Values.persistence.annotations }}
+        annotations:
+          {{ toYaml . | nindent 10 | trim }}
+      {{- end }}
       spec:
         accessModes: {{ .Values.persistence.accessModes }}
         storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/ssv-node/values.yaml
+++ b/charts/ssv-node/values.yaml
@@ -75,6 +75,7 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 5Gi
+  annotations: {}
 
 ## Node labels for pod assignment
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/charts/teku/templates/statefulset.yaml
+++ b/charts/teku/templates/statefulset.yaml
@@ -225,6 +225,10 @@ spec:
         name: data
         labels:
           {{- include "common.labels.standard" . | nindent 10 }}
+      {{- with .Values.persistence.annotations }}
+        annotations:
+          {{ toYaml . | nindent 10 | trim }}
+      {{- end }}
       spec:
         accessModes: {{ .Values.persistence.accessModes }}
         storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/teku/values.yaml
+++ b/charts/teku/values.yaml
@@ -185,6 +185,7 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 300Gi
+  annotations: {}
 
 
 ## Teku is an open-source Ethereum 2.0 client written in Java.

--- a/charts/whitelist/templates/statefulset.yaml
+++ b/charts/whitelist/templates/statefulset.yaml
@@ -96,6 +96,10 @@ spec:
         name: data
         labels:
           {{- include "common.labels.standard" . | nindent 10 }}
+      {{- with .Values.persistence.annotations }}
+        annotations:
+          {{ toYaml . | nindent 10 | trim }}
+      {{- end }}
       spec:
         accessModes: {{ .Values.persistence.accessModes }}
         storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/whitelist/values.yaml
+++ b/charts/whitelist/values.yaml
@@ -127,3 +127,4 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 1Gi
+  annotations: {}


### PR DESCRIPTION
Some cloud providers use annotations for persistent volumes to differentiate between storage types within a storage class. This PR adds the granularity to the respective statefulset templates. The affected statefulset templates are:

* EL and CL clients
* ssv-node
* whitelist