### PR TITLE
feat(validators): add imagePullSecrets template to statefulset

### DIFF
--- a/charts/validators/templates/statefulset.yaml
+++ b/charts/validators/templates/statefulset.yaml
@@ -38,6 +38,10 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $root.Template.BasePath "/configmap.yaml") $root | sha256sum }}
     spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with $root.Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
     {{- end }}


### PR DESCRIPTION
Hey guys,

somehow there was missing the imagePullSecrets template string in stratefulset of validator chart - the default value is already present.