### PR TITLE
Update client versions

### DIFF
--- a/charts/erigon/Chart.yaml
+++ b/charts/erigon/Chart.yaml
@@ -24,13 +24,13 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2022.04.01"
+appVersion: "v2022.06.06"
 
 dependencies:
   - name: common

--- a/charts/erigon/values.yaml
+++ b/charts/erigon/values.yaml
@@ -24,7 +24,7 @@ image:
   repository: thorax/erigon
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v2022.04.01"
+  tag: "v2022.06.06"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/geth/Chart.yaml
+++ b/charts/geth/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: geth
-version: 1.0.6
+version: 1.0.7
 kubeVersion: "^1.18.0-0"
 description: Official Golang implementation of the Ethereum v1 protocol.
 type: application
@@ -16,7 +16,7 @@ maintainers:
   - name: Dmitri Tsumak
     email: dmitri@stakewise.io
 icon: https://raw.githubusercontent.com/ethereum/ethereum-org/master/public/images/logos/ETHEREUM-ICON_Black.png
-appVersion: v1.10.17
+appVersion: v1.10.19
 
 dependencies:
   - name: common

--- a/charts/geth/values.yaml
+++ b/charts/geth/values.yaml
@@ -80,7 +80,7 @@ sidecar:
 ##
 image:
   repository: "ethereum/client-go"
-  tag: "v1.10.17"
+  tag: "v1.10.19"
   pullPolicy: IfNotPresent
 
 ## Credentials to fetch images from private registry

--- a/charts/lighthouse/Chart.yaml
+++ b/charts/lighthouse/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
   - name: Dmitri Tsumak
     email: dmitri@stakewise.io
 icon: https://raw.githubusercontent.com/ethereum/ethereum-org/master/public/images/logos/ETHEREUM-ICON_Black.png
-appVersion: v2.3.0
+appVersion: v2.3.1
 
 dependencies:
 - name: common

--- a/charts/nethermind/Chart.yaml
+++ b/charts/nethermind/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nethermind
 description: .NET Core Ethereum client
 type: application
-version: 1.0.2
-appVersion: "v1.12.7"
+version: 1.0.3
+appVersion: "v1.13.3"
 keywords:
   - ethereum
   - blockchain

--- a/charts/nethermind/values.yaml
+++ b/charts/nethermind/values.yaml
@@ -26,7 +26,7 @@ image:
   repository: nethermind/nethermind
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.12.7"
+  tag: "1.13.3"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/nimbus/Chart.yaml
+++ b/charts/nimbus/Chart.yaml
@@ -19,13 +19,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "multiarch-v22.4.0"
+appVersion: "multiarch-v22.6.0"
 
 keywords:
   - ethereum

--- a/charts/nimbus/values.yaml
+++ b/charts/nimbus/values.yaml
@@ -24,7 +24,7 @@ image:
   repository: statusim/nimbus-eth2
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "multiarch-v22.4.0"
+  tag: "multiarch-v22.6.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/prysm/Chart.yaml
+++ b/charts/prysm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prysm
-version: 1.2.2
+version: 1.2.3
 kubeVersion: "^1.18.0-0"
 description: Go implementation of Ethereum proof of stake.
 type: application
@@ -16,7 +16,7 @@ maintainers:
   - name: Dmitri Tsumak
     email: dmitri@stakewise.io
 icon: https://raw.githubusercontent.com/ethereum/ethereum-org/master/public/images/logos/ETHEREUM-ICON_Black.png
-appVersion: v2.1.0
+appVersion: v2.1.2
 
 dependencies:
 - name: common

--- a/charts/prysm/values.yaml
+++ b/charts/prysm/values.yaml
@@ -88,7 +88,7 @@ replicaCount: 1
 ##
 image:
   repository: "gcr.io/prysmaticlabs/prysm/beacon-chain"
-  tag: "v2.1.0"
+  tag: "v2.1.2"
   pullPolicy: IfNotPresent
 imageGnosis:
   repository: "ghcr.io/gnosischain/gbc-prysm-beacon-chain"

--- a/charts/teku/Chart.yaml
+++ b/charts/teku/Chart.yaml
@@ -19,13 +19,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "22.5"
+appVersion: "22.6.0"
 
 keywords:
   - ethereum

--- a/charts/teku/values.yaml
+++ b/charts/teku/values.yaml
@@ -26,7 +26,7 @@ image:
   repository: consensys/teku
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "22.5"
+  tag: "22.6.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/validators/Chart.yaml
+++ b/charts/validators/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.7
+version: 2.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.2.7"
+appVersion: "v2.2.8"
 
 keywords:
   - ethereum

--- a/charts/validators/values.yaml
+++ b/charts/validators/values.yaml
@@ -68,16 +68,16 @@ image:
   pullPolicy: IfNotPresent
   prysm:
     repository: "gcr.io/prysmaticlabs/prysm/validator"
-    tag: "v2.1.0"
+    tag: "v2.1.2"
   prysmGnosis:
     repository: "ghcr.io/gnosischain/gbc-prysm-validator"
-    tag: "v2.1.0-gbc"
+    tag: "v2.1.2-gbc"
   lighthouse:
     repository: "sigp/lighthouse"
     tag: "v2.3.1"
   teku:
     repository: "consensys/teku"
-    tag: "22.4"
+    tag: "22.6.0"
 
 ## Credentials to fetch images from private registry
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
This PR updates all client versions to current stable releases except for OpenEthereum which is deprecated.

Especially for EL clients it is important to be up to date because of the upcoming [Gray Glacier](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-5133.md) hardfork.