### PR TITLE
Refactor beacon client rest api settings

### DIFF
--- a/charts/lighthouse/Chart.yaml
+++ b/charts/lighthouse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lighthouse
-version: 1.2.3
+version: 1.2.4
 kubeVersion: "^1.18.0-0"
 description: Rust Ethereum 2.0 Client.
 type: application

--- a/charts/lighthouse/templates/service.yaml
+++ b/charts/lighthouse/templates/service.yaml
@@ -22,9 +22,9 @@ spec:
   clusterIP: None
 {{- end }}
   ports:
-    - name: http
-      port: {{ .Values.rpcPort }}
-      targetPort: http
+    - name: {{ .Values.http.portName }}
+      port: {{ .Values.http.port }}
+      targetPort: {{ .Values.http.portName }}
   {{- if .Values.metrics.enabled }}
     - name: metrics
       port: {{ .Values.metrics.port }}

--- a/charts/lighthouse/templates/statefulset.yaml
+++ b/charts/lighthouse/templates/statefulset.yaml
@@ -105,7 +105,12 @@ spec:
               exec lighthouse
               bn
               --staking
-              --http-address=0.0.0.0
+            {{- if .Values.http.enabled }}
+              --http
+              --http-port={{ .Values.http.port }}
+              --http-address={{ .Values.http.address }}
+              --http-allow-origin={{ .Values.http.allowOrigin }}
+            {{- end}}
               --eth1-endpoints={{ .Values.eth1Endpoints | join "," }}
               --datadir=/data
               --network={{ .Values.network }}
@@ -136,9 +141,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           ports:
-            - containerPort: {{ .Values.rpcPort }}
+            - containerPort: {{ .Values.http.port }}
               protocol: TCP
-              name: http
+              name: {{ .Values.http.portName }}
           {{- if .Values.metrics.enabled }}
             - containerPort: {{ .Values.metrics.port }}
               name: metrics
@@ -170,7 +175,7 @@ spec:
             - name: SERVER_BINDADDR
               value: "{{ .Values.sidecar.bindAddr }}:{{ .Values.sidecar.bindPort }}"
             - name: CLIENT_PORT
-              value: {{ .Values.rpcPort | quote }}
+              value: {{ .Values.http.port | quote }}
           ports:
             - containerPort: {{ .Values.sidecar.bindPort }}
               name: sidecar

--- a/charts/lighthouse/templates/tests/test-connection.yaml
+++ b/charts/lighthouse/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "common.names.fullname" . }}:{{ .Values.rpcPort }}']
+      args: ['{{ include "common.names.fullname" . }}:{{ .Values.http.port }}']
   restartPolicy: Never

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -136,9 +136,19 @@ verticalAutoscaler:
 ##
 network: mainnet
 
-## RPC Port
+## Rest API Settings
 ##
-rpcPort: "5052"
+http:
+  # Enables Beacon Rest API
+  enabled: true
+  # Port of the REST server
+  port: "5052"
+  # Port name for the respective k8s service
+  portName: "http"
+  # Listening address of the REST server
+  address: "0.0.0.0"
+  # Access-Control-Allow-Origin response HTTP header
+  allowOrigin: "*"
 
 ## When p2pNodePort is enabled, your P2P port will be exposed via service type NodePort/LoadBalancer.
 ## This will generate a service for each replica, with a port binding via NodePort/LoadBalancer.

--- a/charts/nimbus/Chart.yaml
+++ b/charts/nimbus/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nimbus/templates/service.yaml
+++ b/charts/nimbus/templates/service.yaml
@@ -24,9 +24,9 @@ spec:
   {{- end }}
   {{- if .Values.rest.enabled }}
     - port: {{ .Values.rest.port }}
-      targetPort: rest
+      targetPort: {{ .Values.rest.portName }}
       protocol: TCP
-      name: rest
+      name: {{ .Values.rest.portName }}
   {{- end }}
   {{- if .Values.metrics.enabled }}
     - port: {{ .Values.metrics.port }}

--- a/charts/nimbus/templates/statefulset.yaml
+++ b/charts/nimbus/templates/statefulset.yaml
@@ -84,7 +84,7 @@ spec:
               protocol: TCP
           {{- end }}
           {{- if .Values.rest.enabled }}
-            - name: rest
+            - name: {{ .Values.rest.portName }}
               containerPort: {{ .Values.rest.port }}
               protocol: TCP
           {{- end }}

--- a/charts/nimbus/values.yaml
+++ b/charts/nimbus/values.yaml
@@ -173,10 +173,12 @@ rpc:
 # REST Server settings
 rest:
   enabled: true
-  # Port for the REST server
+  # Port of the REST server
   port: "5052"
+  # Port name for the respective k8s service
+  portName: "rest"
   # Listening address of the REST server
-  address: 0.0.0.0
+  address: "0.0.0.0"
 
 ## Extra flags to pass to the node
 ##

--- a/charts/prysm/Chart.yaml
+++ b/charts/prysm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prysm
-version: 1.2.3
+version: 1.2.4
 kubeVersion: "^1.18.0-0"
 description: Go implementation of Ethereum proof of stake.
 type: application

--- a/charts/prysm/templates/service.yaml
+++ b/charts/prysm/templates/service.yaml
@@ -22,9 +22,9 @@ spec:
   clusterIP: None
 {{- end }}
   ports:
-    - name: rpc
+    - name: {{ .Values.rpc.portName }}
       port: {{ .Values.rpc.port }}
-      targetPort: rpc
+      targetPort: {{ .Values.rpc.portName }}
   {{- if .Values.http.enabled }}
     - name: http
       port: {{ .Values.http.port }}

--- a/charts/prysm/templates/statefulset.yaml
+++ b/charts/prysm/templates/statefulset.yaml
@@ -126,7 +126,7 @@ spec:
         {{- end }}
           args:
             - "--datadir=/data"
-            - "--rpc-host=0.0.0.0"
+            - "--rpc-host={{ .Values.rpc.host }}"
             - "--rpc-port={{ .Values.rpc.port }}"
           {{- if .Values.p2pNodePort.enabled }}
             - "--config-file=/env/init-nodeport"
@@ -174,7 +174,7 @@ spec:
                   fieldPath: status.podIP
           ports:
             - containerPort: {{ .Values.rpc.port }}
-              name: rpc
+              name: {{ .Values.rpc.portName }}
               protocol: TCP
           {{- if .Values.p2pNodePort.enabled }}
             - name: p2p-tcp

--- a/charts/prysm/values.yaml
+++ b/charts/prysm/values.yaml
@@ -134,10 +134,15 @@ p2pNodePort:
       ##
       pullPolicy: IfNotPresent
 
-## RPC Port
+## Settings for gRPC (beacon client api)
 ##
 rpc:
+  # Port number for beacon client rpc connection
   port: "4000"
+  # Host on which the RPC server should listen
+  host: "0.0.0.0"
+  # Port name for the respective k8s service
+  portName: "rpc"
 
 ## HTTP Port
 ##

--- a/charts/teku/Chart.yaml
+++ b/charts/teku/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.3
+version: 1.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/teku/templates/service.yaml
+++ b/charts/teku/templates/service.yaml
@@ -19,9 +19,9 @@ spec:
   ports:
   {{- if .Values.restApi.enabled }}
     - port: {{ .Values.restApi.port }}
-      targetPort: rest-api
+      targetPort: {{ .Values.restApi.portName }}
       protocol: TCP
-      name: rest-api
+      name: {{ .Values.restApi.portName }}
   {{- end }}
   {{- if .Values.metrics.enabled }}
     - port: {{ .Values.metrics.port }}

--- a/charts/teku/templates/statefulset.yaml
+++ b/charts/teku/templates/statefulset.yaml
@@ -141,7 +141,7 @@ spec:
         {{- if or .Values.restApi.enabled .Values.metrics.enabled }}
           ports:
           {{- if .Values.restApi.enabled }}
-            - name: rest-api
+            - name: {{ .Values.restApi.portName }}
               containerPort: {{ .Values.restApi.port }}
               protocol: TCP
           {{- end }}

--- a/charts/teku/values.yaml
+++ b/charts/teku/values.yaml
@@ -259,6 +259,8 @@ restApi:
   interface: "0.0.0.0"
   # Port number of Beacon Rest API
   port: "5051"
+  # Port name for the respective k8s service
+  portName: "rest-api"
   # Comma separated list of origins to allow, or * to
   # allow any origin
   corsOrigins:


### PR DESCRIPTION
This PR refactors the beacon client rest api settings. In general it contains the following improvements:
* Adding a `portName` variable to easily configure the port name for the respective beacon client service

For prysm and lighthouse it contains further small improvements with regards to the rest api settings:
* prysm
  * Add parameter `host` to values.yaml and update the statefulset accordingly
* lighthouse
  * Add a settings block for rest api to values.yaml
  * Include all important rest settings in the aforementioned code block
  * Incorporates the settings block within the statefulset chart to be in line with the other client implementations
  