### PR TITLE
Fix statefulset for missing '.'

### DIFF
--- a/charts/geth/templates/statefulset.yaml
+++ b/charts/geth/templates/statefulset.yaml
@@ -164,7 +164,7 @@ spec:
             - name: ws
               containerPort: {{ $root.Values.ws.port }}
           {{- end }}
-          {{- if $root.Values.globalmetrics.enabled }}
+          {{- if $root.Values.global.metrics.enabled }}
             - name: metrics
               containerPort: {{ $root.Values.metrics.port }}
           {{- end }}


### PR DESCRIPTION
I missed one '.' in my last PR. Sorry for that.
I do not increase the version number for that fix.