### PR TITLE
DRAFT: Fix flag '--JsonRpc.AdditionalRpcUrls' for nethermind

### DIFF
--- a/charts/nethermind/templates/statefulset.yaml
+++ b/charts/nethermind/templates/statefulset.yaml
@@ -117,7 +117,7 @@ spec:
               --JsonRpc.Host={{ $root.Values.jsonrpc.host }}
               --JsonRpc.Port={{ $root.Values.jsonrpc.ports.rest }}
               --JsonRpc.WebSocketsPort={{ $root.Values.jsonrpc.ports.websocket }}
-              --JsonRpc.AdditionalRpcUrls={{ $root.Values.jsonrpc.additionalRpcUrls }}
+              --JsonRpc.AdditionalRpcUrls="http://{{ $root.Values.jsonrpc.engine.host }}:{{ $root.Values.jsonrpc.engine.port }}|http;ws|net;eth;subscribe;engine;web3;client"
           {{- end }}
           {{- if $root.Values.global.JWTSecret }}
               --JsonRpc.JwtSecretFile=/secret/jwtsecret

--- a/charts/nethermind/values.yaml
+++ b/charts/nethermind/values.yaml
@@ -138,7 +138,7 @@ jsonrpc:
     websocket: "8546"
   engine:
     port: "8551"
-  additionalRpcUrls: "http://0.0.0.0:8551|http;ws|net;eth;subscribe;engine;web3;client"
+    host: "0.0.0.0"
 
 merge:
   # Defines whether the Merge plugin is enabled bundles are allowed.


### PR DESCRIPTION
Nethermind expects a string in `""` for the mentioned cli flag but when parsed via the templating engine from values.yml the `""` get deleted. 

Therefore, the following changes were made:
* Add `""` manually in the respective value of flag `--JsonRpc.AdditionalRpcUrls` in the statefulset
* Hardcode most of the expected string due to the fact that this flag will not be necessary with the release of the next version.
* Add engine port and host in values.yml which already reflect the upcoming cli flag changes, namely `--JsonRpc.EnginePort` and `--JsonRpc.EngineHost`