### PR TITLE
Fix metrics path for teku, prysm and nethermind

### DIFF
--- a/charts/nethermind/templates/servicemonitor.yaml
+++ b/charts/nethermind/templates/servicemonitor.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   endpoints:
     - port: metrics
-      path: /debug/metrics/prometheus
+      path: /metrics
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}

--- a/charts/prysm/templates/servicemonitor.yaml
+++ b/charts/prysm/templates/servicemonitor.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   endpoints:
     - port: metrics
-      path: /debug/metrics/prometheus
+      path: /metrics
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}

--- a/charts/teku/templates/servicemonitor.yaml
+++ b/charts/teku/templates/servicemonitor.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   endpoints:
     - port: metrics
-      path: /debug/metrics/prometheus
+      path: /metrics
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}


### PR DESCRIPTION
The metrics path in the serviceMonitors of the above mentioned charts were incorrect. This PR fixes it. 