### PR TITLE
Draft: fix(lighthouse): add prometheusrules rules for each instance

### DIFF
--- a/charts/lighthouse/templates/prometheusrules.yaml
+++ b/charts/lighthouse/templates/prometheusrules.yaml
@@ -16,15 +16,16 @@ metadata:
     {{- end }}
 spec:
   groups:
-  {{- with .Values.metrics.prometheusRule.rules }}
-    - name: {{ include "common.names.fullname" $ }}
+  {{- range $i, $e := until (len .Values.global.executionEndpoints) }}
+  {{- with $.Values.metrics.prometheusRule.rules }}
+    - name: {{ include "common.names.fullname" $ }}-{{ $i }}
       rules: {{- tpl (toYaml .) $ | nindent 8 }}
   {{- end }}
-  {{- if .Values.metrics.prometheusRule.default }}
-    - name: {{ include "common.names.fullname" $ }}-default
+  {{- if $.Values.metrics.prometheusRule.default }}
+    - name: {{ include "common.names.fullname" $ }}-{{ $i }}-default
       rules:
         - alert: LighthouseBeaconNodeDown
-          expr: up{job='{{ include "common.names.fullname" . }}'} == 0
+          expr: up{job='{{ include "common.names.fullname" $ }}-{{ $i }}'} == 0
           for: 1m
           labels:
             severity: critical
@@ -32,7 +33,7 @@ spec:
             summary: Lighthouse beacon node is down
             description: Check {{ printf "{{ $labels.pod }}" }} beacon node in namespace {{ printf "{{ $labels.namespace }}" }}
         - alert: LighthouseBeaconNodeIsNotConnectedToEth1Node
-          expr: sync_eth1_connected{job='{{ include "common.names.fullname" . }}'} == 0
+          expr: sync_eth1_connected{job='{{ include "common.names.fullname" $ }}-{{ $i }}'} == 0
           for: 1m
           labels:
             severity: critical
@@ -40,12 +41,13 @@ spec:
             summary: Lighthouse beacon node is not connected to eth1 node
             description: Check {{ printf "{{ $labels.pod }}" }} beacon node in namespace {{ printf "{{ $labels.namespace }}" }}
         - alert: LighthouseBeaconNodeIsOutOfSync
-          expr: sync_eth2_synced{job='{{ include "common.names.fullname" . }}'} == 0
+          expr: sync_eth2_synced{job='{{ include "common.names.fullname" $ }}-{{ $i }}'} == 0
           for: 3m
           labels:
             severity: critical
           annotations:
             summary: Lighthouse beacon node is out of sync
             description: Check {{ printf "{{ $labels.pod }}" }} beacon node in namespace {{ printf "{{ $labels.namespace }}" }}
+  {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Hey @unxnn,

cause all beacon clients create a range of statefulsets/pods, we need to do the same for prometheusrules, otherwise the instances can't be monitored seperately.

**To-Dos:**
- [ ] Test lighthouse changes
- [ ] Update other beacon clients.