### PR TITLE
fix(validators): align prometheusRule additional rules with other charts

### DIFF
--- a/charts/validators/templates/prometheusrules.yaml
+++ b/charts/validators/templates/prometheusrules.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   groups:
-  {{- with (pluck .Values.type .Values.metrics.prometheusRule.rules | first) }}
+  {{- with .Values.metrics.prometheusRule.rules }}
     - name: {{ template "validators.fullname" $ }}
       rules: {{- tpl (toYaml .) $ | nindent 8 }}
   {{- end }}


### PR DESCRIPTION
Hey @unxnn and @tsudmi,

I just wanted to add prometheusRules for validator clients but the `pluck` method is throwing errors (merging dict and array) - so I have aligned it with the other charts.

Cheers!