### PR TITLE
Add checkpoint sync to CL clients

### DIFF
--- a/charts/lighthouse/Chart.yaml
+++ b/charts/lighthouse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lighthouse
-version: 2.1.5
+version: 2.2.5
 kubeVersion: "^1.18.0-0"
 description: Rust Ethereum 2.0 Client.
 type: application

--- a/charts/lighthouse/templates/statefulset.yaml
+++ b/charts/lighthouse/templates/statefulset.yaml
@@ -123,6 +123,9 @@ spec:
               --execution-jwt=/secret/jwtsecret
               --datadir=/data
               --network={{ .Values.global.network }}
+            {{- if .Values.checkpointSyncUrl }}
+              --checkpoint-sync-url={{ .Values.checkpointSyncUrl }}
+            {{- end}}
               --disable-upnp
               --disable-enr-auto-update
               --target-peers={{ .Values.targetPeers }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -135,6 +135,13 @@ http:
   # Access-Control-Allow-Origin response HTTP header
   allowOrigin: "*"
 
+## If set, lighthouse will perform a checkpoint sync. For more information see here: https://lighthouse-book.sigmaprime.io/checkpoint-sync.html
+## Respective public checkpoint sync endpoints can be found here: https://eth-clients.github.io/checkpoint-sync-endpoints/
+## It is not recommended to blindly trust any public beacon node.
+## Therefore please verify that you are on the correct chain: https://notes.ethereum.org/@launchpad/checkpoint-sync#1-Obtaining-finalized-checkpoint-amp-state-root 
+##
+checkpointSyncUrl: ""
+
 ## The target number of peers.
 ##
 targetPeers: 80

--- a/charts/prysm/Chart.yaml
+++ b/charts/prysm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prysm
-version: 3.2.2
+version: 3.3.2
 appVersion: v3.1.0
 kubeVersion: "^1.18.0-0"
 description: Go implementation of Ethereum proof of stake.

--- a/charts/prysm/templates/statefulset.yaml
+++ b/charts/prysm/templates/statefulset.yaml
@@ -154,6 +154,11 @@ spec:
             - "--chain-config-file=/data/gnosis-config/config.yaml"
           {{- end }}
 
+          {{- if .Values.checkpointSyncUrl }}
+            - "--checkpoint-sync-url={{ .Values.checkpointSyncUrl }}"
+            - "--genesis-beacon-api-url={{ .Values.checkpointSyncUrl }}"
+          {{- end}}
+
           {{- range .Values.extraFlags }}
             - {{ . | quote }}
           {{- end }}

--- a/charts/prysm/values.yaml
+++ b/charts/prysm/values.yaml
@@ -219,6 +219,13 @@ http:
   enabled: true
   port: "8080"
 
+## If set, prysm will perform a checkpoint sync via network request. For more information see here: https://docs.prylabs.network/docs/prysm-usage/checkpoint-sync#option-1-configure-checkpoint-sync-via-network-request
+## Respective public checkpoint sync endpoints can be found here: https://eth-clients.github.io/checkpoint-sync-endpoints/
+## It is not recommended to blindly trust any public beacon node.
+## Therefore please verify that you are on the correct chain: https://notes.ethereum.org/@launchpad/checkpoint-sync#1-Obtaining-finalized-checkpoint-amp-state-root 
+##
+checkpointSyncUrl: ""
+
 ## Ethereum 1 node endpoints.
 ##
 eth1Endpoints: []

--- a/charts/teku/Chart.yaml
+++ b/charts/teku/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.5
+version: 2.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/teku/templates/statefulset.yaml
+++ b/charts/teku/templates/statefulset.yaml
@@ -115,6 +115,9 @@ spec:
             {{- end }}
               exec /opt/teku/bin/teku
               --network={{ .Values.global.network }}
+            {{- if .Values.initialState }}
+              --initial-state={{ .Values.initialState }}/eth/v2/debug/beacon/states/finalized
+            {{- end }}
               --config-file=/data/teku/config.yaml
               --data-beacon-path=/data/teku/beacon
               --data-path=/data/teku

--- a/charts/teku/values.yaml
+++ b/charts/teku/values.yaml
@@ -341,6 +341,16 @@ restApi:
   # Enable swagger-docs and swagger-ui endpoints
   docsEnabled: false
 
+## If set, teku will download a recent finalized checkpoint state from a beacon node. For more information see here: https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Checkpoint-Start/
+## Respective public checkpoint sync endpoints can be found here: https://eth-clients.github.io/checkpoint-sync-endpoints/
+## It is not recommended to blindly trust any public beacon node.
+## Therefore please verify that you are on the correct chain: https://notes.ethereum.org/@launchpad/checkpoint-sync#1-Obtaining-finalized-checkpoint-amp-state-root
+## Note:
+## Additionally to the checkpoint sync url Teku needs the following path to obtain the finalized state: /eth/v2/debug/beacon/states/finalized
+## To keep UX similar across all charts, the path is hardcoded in the statefulset, so you DON'T need to add it here.
+##
+initialState: ""
+
 ## Monitoring
 ##
 metrics:


### PR DESCRIPTION
## Overview
Since checkpoint sync is such an important feature I think it is relevant to add this setting as a separate configuration option instead of putting it into `extraFlags`. Therefore, this PR adds checkpoint sync to teku, prysm and lighthouse.

## Note on Nimbus
This PR does not add checkpoint sync to nimbus as the nimbus chart is in general outdated compared to the other CL client charts (refers to the still present `range` functionality in nimbus which was excluded from the other CL client charts). Therefore nimbus needs a full rework and will be handled in a separate PR.

## Changes
* Add checkpoint sync logic to teku, lighthouse and prysm statefulset template
* Add checkpoint sync option to teku, lighthouse and prysm values.yaml
* Add small documentation where to find public checkpoints and how to confirm the correct state

## Versioning
Chart versions are increased as this can be interpreted as new feature and not only as a fix.