### PR TITLE
Open EL clients for incoming p2p traffic

### DIFF
--- a/charts/erigon/Chart.yaml
+++ b/charts/erigon/Chart.yaml
@@ -24,7 +24,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.3
+version: 2.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/erigon/templates/statefulset.yaml
+++ b/charts/erigon/templates/statefulset.yaml
@@ -95,7 +95,6 @@ spec:
               --chain={{ .Values.global.network }}
           {{- if .Values.p2pNodePort.enabled }}
               --nat=extip:$EXTERNAL_IP
-              --port=$EXTERNAL_PORT
           {{- else }}
               --nat=extip:$(POD_IP)
               --port={{ include "erigon.p2pPort" . }}

--- a/charts/geth/Chart.yaml
+++ b/charts/geth/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: geth
-version: 2.1.8
+version: 2.1.9
 kubeVersion: "^1.18.0-0"
 description: Official Golang implementation of the Ethereum v1 protocol.
 type: application

--- a/charts/geth/templates/statefulset.yaml
+++ b/charts/geth/templates/statefulset.yaml
@@ -118,7 +118,6 @@ spec:
           {{- end }}
           {{- if .Values.p2pNodePort.enabled }}
               --nat=extip:$EXTERNAL_IP
-              --port=$EXTERNAL_PORT
           {{- else }}
               --nat=extip:$(POD_IP)
               --port={{ include "geth.p2pPort" . }}

--- a/charts/nethermind/Chart.yaml
+++ b/charts/nethermind/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nethermind
 description: .NET Core Ethereum client
 type: application
-version: 2.2.1
+version: 2.2.2
 appVersion: "v1.14.7"
 keywords:
   - ethereum

--- a/charts/nethermind/templates/statefulset.yaml
+++ b/charts/nethermind/templates/statefulset.yaml
@@ -126,8 +126,6 @@ spec:
           {{- end }}
           {{- if .Values.p2pNodePort.enabled }}
               --Network.ExternalIp=$EXTERNAL_IP
-              --Network.P2PPort=$EXTERNAL_PORT
-              --Network.DiscoveryPort=$EXTERNAL_PORT
           {{- else }}
               --Network.ExternalIp=$(POD_IP)
               --Network.P2PPort={{ include "nethermind.p2pPort" . }}


### PR DESCRIPTION
## Summary
Currently the incoming p2p traffic is not working as the p2p port of the pod is overwritten with the external port which is extracted via kubectl in the init container. However, the created p2p services want to map the external port to the clients default p2p port which will not work due to overwriting the p2p port. This PR fixes the issue for `geth`, `nethermind` and `erigon`.

## Out of scope
The bug is not present in the `besu` chart. However, incoming p2p traffic will not work anyways as no respective client flags are set in the case the user activates the setting `p2pNodePort` in the values.yaml. I don't run besu currently so I cannot test it. I encourage the stakewise team to check the statefulset template and add the respective flags. From the help of `besu` I would assume that `--p2p-host` could be the correct flag were to set the external IP. Please do not overwrite the p2p port as for the other clients.