### PR TITLE
Add image registry to all values and template files

### DIFF
--- a/charts/backend/templates/admin-deployment.yaml
+++ b/charts/backend/templates/admin-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       priorityClassName: {{ .Values.admin.priorityClassName | quote }}
       initContainers:
         - name: initdb
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["python", "manage.py", "migrate", "--no-input"]
           envFrom:
@@ -59,7 +59,7 @@ spec:
               value: {{ .Values.admin.conf.allowedHosts | quote }}
         {{- if .Values.admin.user.create }}
         - name: init-admin
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c", "python manage.py create_superuser"]
           envFrom:
@@ -77,7 +77,7 @@ spec:
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - configMapRef:

--- a/charts/backend/templates/api-deployment.yaml
+++ b/charts/backend/templates/api-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       priorityClassName: {{ .Values.api.priorityClassName | quote }}
       initContainers:
         - name: migrate-db
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["python", "manage.py", "migrate", "--no-input"]
           envFrom:
@@ -59,7 +59,7 @@ spec:
               value: "config.settings.api_settings"
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:

--- a/charts/backend/templates/celery-beat.yaml
+++ b/charts/backend/templates/celery-beat.yaml
@@ -37,7 +37,7 @@ spec:
       priorityClassName: {{ .Values.admin.priorityClassName | quote }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/start-celerybeat"]
           envFrom:

--- a/charts/backend/templates/celery-flower.yaml
+++ b/charts/backend/templates/celery-flower.yaml
@@ -37,7 +37,7 @@ spec:
       priorityClassName: {{ .Values.admin.priorityClassName | quote }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/start-flower"]
           envFrom:

--- a/charts/backend/templates/celery-worker.yaml
+++ b/charts/backend/templates/celery-worker.yaml
@@ -37,7 +37,7 @@ spec:
       priorityClassName: {{ .Values.admin.priorityClassName | quote }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/start-celeryworker"]
           envFrom:

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -46,7 +46,8 @@ commonConf:
   multisigOwnersTelegramChatId: ""
 
 image:
-  repository: "europe-west4-docker.pkg.dev/stakewiselabs/private/backend"
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/private/backend"
   tag: "v2.4.23"
   pullPolicy: IfNotPresent
   pullSecrets: [ ]

--- a/charts/besu/templates/statefulset.yaml
+++ b/charts/besu/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
         {{- toYaml .Values.securityContext | nindent 8 }}
       initContainers:
         - name: init
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsNonRoot: false
@@ -95,7 +95,7 @@ spec:
               mountPath: /data
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh

--- a/charts/besu/values.yaml
+++ b/charts/besu/values.yaml
@@ -83,6 +83,7 @@ global:
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
+  registry: ""
   repository: "bitnami/kubectl"
   tag: "1.24"
   pullPolicy: IfNotPresent
@@ -90,6 +91,7 @@ initImage:
 ## Besu image
 ##
 image:
+  registry: ""
   repository: hyperledger/besu
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/charts/contract-watcher/templates/deployment.yaml
+++ b/charts/contract-watcher/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: WS_URL

--- a/charts/contract-watcher/values.yaml
+++ b/charts/contract-watcher/values.yaml
@@ -10,7 +10,8 @@ global:
 replicaCount: 1
 
 image:
-  repository: europe-west4-docker.pkg.dev/stakewiselabs/private/contract-watcher
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/private/contract-watcher"
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "v0.0.2"

--- a/charts/erigon/templates/statefulset.yaml
+++ b/charts/erigon/templates/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: {{ include "common.names.serviceAccountName" . }}
       initContainers:
         - name: init
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsNonRoot: false
@@ -80,7 +80,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh
@@ -173,7 +173,7 @@ spec:
               mountPath: /env
           {{- end }}
         - name: sidecar
-          image: "{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
+          image: "{{ .Values.sidecar.registry }}/{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
           imagePullPolicy: {{ .Values.sidecar.pullPolicy }}
           env:
             - name: SERVER_BINDADDR

--- a/charts/erigon/values.yaml
+++ b/charts/erigon/values.yaml
@@ -77,6 +77,7 @@ global:
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
+  registry: ""
   repository: "bitnami/kubectl"
   tag: "1.24"
   pullPolicy: IfNotPresent
@@ -84,13 +85,15 @@ initImage:
 ## Sidecar image is used to perform Liveness/Readiness probes.
 ##
 sidecar:
-  repository: "europe-west4-docker.pkg.dev/stakewiselabs/public/ethnode-sidecar"
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/ethnode-sidecar"
   tag: "v1.0.6"
   pullPolicy: IfNotPresent
   bindAddr: "0.0.0.0"
   bindPort: 3000
 
 image:
+  registry: ""
   repository: thorax/erigon
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/charts/geth/templates/statefulset.yaml
+++ b/charts/geth/templates/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       initContainers:
         - name: init
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsNonRoot: false
@@ -92,7 +92,7 @@ spec:
               mountPath: /env
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh
@@ -191,7 +191,7 @@ spec:
         {{- end }}
       {{- if .Values.http.enabled }}
         - name: sidecar
-          image: "{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
+          image: "{{ .Values.sidecar.registry }}/{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
           imagePullPolicy: {{ .Values.sidecar.pullPolicy }}
           env:
             - name: SERVER_BINDADDR

--- a/charts/geth/values.yaml
+++ b/charts/geth/values.yaml
@@ -77,6 +77,7 @@ global:
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
+  registry: ""
   repository: "bitnami/kubectl"
   tag: "1.24"
   pullPolicy: IfNotPresent
@@ -84,7 +85,8 @@ initImage:
 ## Sidecar image is used to perform Liveness/Readiness probes.
 ##
 sidecar:
-  repository: "europe-west4-docker.pkg.dev/stakewiselabs/public/ethnode-sidecar"
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/ethnode-sidecar"
   tag: "v1.0.6"
   pullPolicy: IfNotPresent
   bindAddr: "0.0.0.0"
@@ -94,6 +96,7 @@ sidecar:
 ## ref: https://hub.docker.com/r/ethereum/client-go/tags/
 ##
 image:
+  registry: ""
   repository: "ethereum/client-go"
   tag: "v1.10.26"
   pullPolicy: IfNotPresent

--- a/charts/graph-node/templates/statefulset.yaml
+++ b/charts/graph-node/templates/statefulset.yaml
@@ -47,7 +47,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - configMapRef:

--- a/charts/graph-node/values.yaml
+++ b/charts/graph-node/values.yaml
@@ -9,6 +9,7 @@ global:
 replicaCount: 1
 
 image:
+  registry: ""
   repository: graphprotocol/graph-node
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/charts/horcrux/templates/dispatcher-deployment.yaml
+++ b/charts/horcrux/templates/dispatcher-deployment.yaml
@@ -42,7 +42,7 @@ spec:
       priorityClassName: {{ .Values.dispatcher.priorityClassName | quote }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [ "uvicorn", "--host=0.0.0.0", "--port=8000", "dispatcher.main:app" ]
           envFrom:

--- a/charts/horcrux/values.yaml
+++ b/charts/horcrux/values.yaml
@@ -3,6 +3,7 @@ securityContext:
   runAsUser: 1001
 
 image:
+  registry: ""
   repository: "stakewiselabs/bls-horcrux"
   tag: "v1.0.0"
   pullPolicy: IfNotPresent

--- a/charts/ipfs/templates/statefulset.yaml
+++ b/charts/ipfs/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
       {{- if and .Values.persistence.enabled .Values.initChownData }}
       initContainers:
         - name: init-chown
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsUser: 0
@@ -47,7 +47,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ include "common.names.fullname" . }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - configMapRef:

--- a/charts/ipfs/values.yaml
+++ b/charts/ipfs/values.yaml
@@ -20,11 +20,13 @@ securityContext:
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
+  registry: ""
   repository: "busybox"
   tag: "1.34"
   pullPolicy: IfNotPresent
 
 image:
+  registry: ""
   repository: ipfs/kubo
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/charts/keeper/templates/deployment.yaml
+++ b/charts/keeper/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["python"]
           args: ["oracle/keeper/main.py"]

--- a/charts/keeper/values.yaml
+++ b/charts/keeper/values.yaml
@@ -40,7 +40,8 @@ serviceAccount:
 ## Docker image
 ##
 image:
-  repository: "europe-west4-docker.pkg.dev/stakewiselabs/public/oracle"
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/oracle"
   tag: "v2.8.10"
   pullPolicy: IfNotPresent
 

--- a/charts/lighthouse/templates/statefulset.yaml
+++ b/charts/lighthouse/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       initContainers:
         - name: init
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsNonRoot: false
@@ -99,7 +99,7 @@ spec:
               mountPath: /configs
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh
@@ -182,7 +182,7 @@ spec:
             {{ toYaml . | nindent 12 | trim }}
         {{- end }}
         - name: sidecar
-          image: "{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
+          image: "{{ .Values.sidecar.registry }}/{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
           imagePullPolicy: {{ .Values.sidecar.pullPolicy }}
           env:
             - name: SERVER_BINDADDR

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -84,6 +84,7 @@ global:
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
+  registry: ""
   repository: "bitnami/kubectl"
   tag: "1.24"
   pullPolicy: IfNotPresent
@@ -91,7 +92,8 @@ initImage:
 ## Sidecar image is used to perform Liveness/Readiness probes.
 ##
 sidecar:
-  repository: "europe-west4-docker.pkg.dev/stakewiselabs/public/ethnode-sidecar"
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/ethnode-sidecar"
   tag: "v1.0.6"
   pullPolicy: IfNotPresent
   bindAddr: "0.0.0.0"
@@ -104,6 +106,7 @@ sidecar:
 ## Lighthouse beacon node image version
 ## ref: https://hub.docker.com/r/sigp/lighthouse
 image:
+  registry: ""
   repository: "sigp/lighthouse"
   tag: "v3.4.0"
   pullPolicy: IfNotPresent

--- a/charts/mev-boost/templates/deployment.yaml
+++ b/charts/mev-boost/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - -{{ .Values.global.network }}

--- a/charts/mev-boost/values.yaml
+++ b/charts/mev-boost/values.yaml
@@ -32,6 +32,7 @@ extraFlags: []
 replicaCount: 1
 
 image:
+  registry: ""
   repository: flashbots/mev-boost
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/charts/nethermind/templates/statefulset.yaml
+++ b/charts/nethermind/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
         {{- toYaml .Values.securityContext | nindent 8 }}
       initContainers:
         - name: init
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsNonRoot: false
@@ -90,7 +90,7 @@ spec:
               mountPath: /env
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           workingDir: /data/nethermind
           command:
@@ -192,7 +192,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if .Values.jsonrpc.enabled }}
         - name: sidecar
-          image: "{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
+          image: "{{ .Values.sidecar.registry }}/{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
           imagePullPolicy: {{ .Values.sidecar.pullPolicy }}
           env:
             - name: SERVER_BINDADDR

--- a/charts/nethermind/values.yaml
+++ b/charts/nethermind/values.yaml
@@ -77,6 +77,7 @@ global:
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
+  registry: ""
   repository: "bitnami/kubectl"
   tag: "1.24"
   pullPolicy: IfNotPresent
@@ -84,7 +85,8 @@ initImage:
 ## Sidecar image is used to perform Liveness/Readiness probes.
 ##
 sidecar:
-  repository: "europe-west4-docker.pkg.dev/stakewiselabs/public/ethnode-sidecar"
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/ethnode-sidecar"
   tag: "v1.0.6"
   pullPolicy: IfNotPresent
   bindAddr: "0.0.0.0"
@@ -93,6 +95,7 @@ sidecar:
 ## Nethermind Image
 ##
 image:
+  registry: ""
   repository: nethermind/nethermind
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/charts/nimbus/templates/statefulset.yaml
+++ b/charts/nimbus/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       initContainers:
         - name: init
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsNonRoot: false
@@ -99,7 +99,7 @@ spec:
               mountPath: /configs
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh
@@ -175,7 +175,7 @@ spec:
             {{ toYaml . | nindent 12 | trim }}
         {{- end }}
         - name: sidecar
-          image: "{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
+          image: "{{ .Values.sidecar.registry }}/{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
           imagePullPolicy: {{ .Values.sidecar.pullPolicy }}
           env:
             - name: SERVER_BINDADDR

--- a/charts/nimbus/values.yaml
+++ b/charts/nimbus/values.yaml
@@ -84,6 +84,7 @@ global:
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
+  registry: ""
   repository: "bitnami/kubectl"
   tag: "1.24"
   pullPolicy: IfNotPresent
@@ -91,7 +92,8 @@ initImage:
 ## Sidecar image is used to perform Liveness/Readiness probes.
 ##
 sidecar:
-  repository: "europe-west4-docker.pkg.dev/stakewiselabs/public/ethnode-sidecar"
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/ethnode-sidecar"
   tag: "v1.0.6"
   pullPolicy: IfNotPresent
   bindAddr: "0.0.0.0"
@@ -100,6 +102,7 @@ sidecar:
 ## Nimbus beacon node image version
 ## ref: https://hub.docker.com/r/statusim/nimbus-eth2
 image:
+  registry: ""
   repository: statusim/nimbus-eth2
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/charts/oracle/templates/deployment.yaml
+++ b/charts/oracle/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["python"]
           args: ["oracle/oracle/main.py"]

--- a/charts/oracle/values.yaml
+++ b/charts/oracle/values.yaml
@@ -40,7 +40,8 @@ serviceAccount:
 ## Docker image
 ##
 image:
-  repository: "europe-west4-docker.pkg.dev/stakewiselabs/public/oracle"
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/oracle"
   tag: "v2.8.10"
   pullPolicy: IfNotPresent
 

--- a/charts/prysm/templates/statefulset.yaml
+++ b/charts/prysm/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       initContainers:
         - name: init
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsNonRoot: false
@@ -116,7 +116,7 @@ spec:
       containers:
         - name: {{ include "common.names.fullname" . }}
         {{- if ne .Values.global.network "gnosis" }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- else }}
           image: "{{ .Values.imageGnosis.repository }}:{{ .Values.imageGnosis.tag }}"
@@ -221,7 +221,7 @@ spec:
         {{- end }}
       {{- if .Values.http.enabled }}
         - name: sidecar
-          image: "{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
+          image: "{{ .Values.sidecar.registry }}/{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
           imagePullPolicy: {{ .Values.sidecar.pullPolicy }}
           env:
             - name: SERVER_BINDADDR

--- a/charts/prysm/values.yaml
+++ b/charts/prysm/values.yaml
@@ -146,6 +146,7 @@ rbac:
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
+  registry: ""
   repository: "bitnami/kubectl"
   tag: "1.24"
   pullPolicy: IfNotPresent
@@ -153,7 +154,8 @@ initImage:
 ## Sidecar image is used to perform Liveness/Readiness probes.
 ##
 sidecar:
-  repository: "europe-west4-docker.pkg.dev/stakewiselabs/public/ethnode-sidecar"
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/ethnode-sidecar"
   tag: "v1.0.6"
   pullPolicy: IfNotPresent
   bindAddr: "0.0.0.0"
@@ -167,11 +169,13 @@ sidecar:
 ## ref: https://gcr.io/prysmaticlabs/prysm/beacon-chain
 ##
 image:
-  repository: "gcr.io/prysmaticlabs/prysm/beacon-chain"
+  registry: "gcr.io"
+  repository: "prysmaticlabs/prysm/beacon-chain"
   tag: "v3.2.0"
   pullPolicy: IfNotPresent
 imageGnosis:
-  repository: "ghcr.io/gnosischain/gbc-prysm-beacon-chain"
+  registry: "ghcr.io"
+  repository: "gnosischain/gbc-prysm-beacon-chain"
   tag: "v2.1.2-gbc"
   pullPolicy: IfNotPresent
 

--- a/charts/ssv-node/templates/statefulset.yaml
+++ b/charts/ssv-node/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
       {{- if and .Values.persistence.enabled .Values.initChownData }}
       initContainers:
         - name: init-chown
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsUser: 0
@@ -47,7 +47,7 @@ spec:
       {{- end }}
       containers:
         - name: node
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['make']
           args: ['start-node']

--- a/charts/ssv-node/values.yaml
+++ b/charts/ssv-node/values.yaml
@@ -7,11 +7,13 @@ replicaCount: 1
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
+  registry: ""
   repository: "busybox"
   tag: "1.34"
   pullPolicy: IfNotPresent
 
 image:
+  registry: ""
   repository: bloxstaking/ssv-node
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/charts/teku/templates/statefulset.yaml
+++ b/charts/teku/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         {{- toYaml .Values.securityContext | nindent 8 }}
       initContainers:
         - name: init
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsNonRoot: false
@@ -102,7 +102,7 @@ spec:
               mountPath: /configs
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh
@@ -181,7 +181,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if .Values.restApi.enabled }}
         - name: sidecar
-          image: "{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
+          image: "{{ .Values.sidecar.registry }}/{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
           imagePullPolicy: {{ .Values.sidecar.pullPolicy }}
           env:
             - name: SERVER_BINDADDR

--- a/charts/teku/values.yaml
+++ b/charts/teku/values.yaml
@@ -84,6 +84,7 @@ global:
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
+  registry: ""
   repository: "bitnami/kubectl"
   tag: "1.24"
   pullPolicy: IfNotPresent
@@ -91,7 +92,8 @@ initImage:
 ## Sidecar image is used to perform Liveness/Readiness probes.
 ##
 sidecar:
-  repository: "europe-west4-docker.pkg.dev/stakewiselabs/public/ethnode-sidecar"
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/ethnode-sidecar"
   tag: "v1.0.6"
   pullPolicy: IfNotPresent
   bindAddr: "0.0.0.0"
@@ -100,6 +102,7 @@ sidecar:
 ## Teku image
 ##
 image:
+  registry: ""
   repository: consensys/teku
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/charts/v3-backend/templates/admin-deployment.yaml
+++ b/charts/v3-backend/templates/admin-deployment.yaml
@@ -42,7 +42,7 @@ spec:
       priorityClassName: {{ .Values.admin.priorityClassName | quote }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["bash", "./scripts/admin.sh"]
           envFrom:

--- a/charts/v3-backend/templates/app-deployment.yaml
+++ b/charts/v3-backend/templates/app-deployment.yaml
@@ -42,7 +42,7 @@ spec:
       priorityClassName: {{ .Values.app.priorityClassName | quote }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:

--- a/charts/v3-backend/templates/worker.yaml
+++ b/charts/v3-backend/templates/worker.yaml
@@ -36,7 +36,7 @@ spec:
       priorityClassName: {{ .Values.worker.priorityClassName | quote }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["bash", "./scripts/worker.sh"]
           envFrom:

--- a/charts/v3-backend/values.yaml
+++ b/charts/v3-backend/values.yaml
@@ -52,7 +52,8 @@ settings:
     password: ""
 
 image:
-  repository: "europe-west4-docker.pkg.dev/stakewiselabs/private/v3-backend"
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/private/v3-backend"
   tag: "master"
   pullPolicy: IfNotPresent
   pullSecrets: [ ]

--- a/charts/validator-monitor/templates/deployment.yaml
+++ b/charts/validator-monitor/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: BIND_ADDRESS

--- a/charts/validator-monitor/values.yaml
+++ b/charts/validator-monitor/values.yaml
@@ -19,7 +19,8 @@ operatorWallets: []
 replicaCount: 1
 
 image:
-  repository: europe-west4-docker.pkg.dev/stakewiselabs/public/validator-monitor
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/validator-monitor"
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "v1.0.0"

--- a/charts/validators/templates/_helpers.tpl
+++ b/charts/validators/templates/_helpers.tpl
@@ -72,7 +72,7 @@ Update permissions on files inside /data directory
 */}}
 {{- define "init-chown" -}}
 - name: init-chown
-  image: "{{ .Values.initImageBusybox.repository }}:{{ .Values.initImageBusybox.tag }}"
+  image: "{{ .Values.initImageBusybox.registry }}/{{ .Values.initImageBusybox.repository }}:{{ .Values.initImageBusybox.tag }}"
   imagePullPolicy: {{ .Values.initImageBusybox.pullPolicy }}
   securityContext:
     runAsUser: 0

--- a/charts/validators/templates/statefulset.yaml
+++ b/charts/validators/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
       priorityClassName: {{ $root.Values.priorityClassName | quote }}
       initContainers:
         - name: get-configs
-          image: "{{ $root.Values.cliImage.repository }}:{{ $root.Values.cliImage.tag }}"
+          image: "{{ $root.Values.cliImage.registry }}/{{ $root.Values.cliImage.repository }}:{{ $root.Values.cliImage.tag }}"
           imagePullPolicy: {{ $root.Values.cliImage.pullPolicy }}
           securityContext:
             runAsUser: 0
@@ -98,7 +98,7 @@ spec:
               mountPath: /fee
           {{- end }}
         - name: prepare
-          image: "{{ $root.Values.initImageBusybox.repository }}:{{ $root.Values.initImageBusybox.tag }}"
+          image: "{{ $root.Values.initImageBusybox.registry }}/{{ $root.Values.initImageBusybox.repository }}:{{ $root.Values.initImageBusybox.tag }}"
           imagePullPolicy: {{ $root.Values.initImageBusybox.pullPolicy }}
           securityContext:
             runAsUser: 0

--- a/charts/validators/values.yaml
+++ b/charts/validators/values.yaml
@@ -30,6 +30,7 @@ rbac:
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImageBusybox:
+  registry: ""
   repository: "busybox"
   tag: "1.35"
   pullPolicy: IfNotPresent
@@ -37,7 +38,8 @@ initImageBusybox:
 ## CLI image is used to fetch public keys.
 ##
 cliImage:
-  repository: europe-west4-docker.pkg.dev/stakewiselabs/public/cli
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/cli"
   tag: "v1.2.7"
   pullPolicy: IfNotPresent
 
@@ -103,15 +105,19 @@ enableBuilder: false
 image:
   pullPolicy: IfNotPresent
   prysm:
-    repository: "gcr.io/prysmaticlabs/prysm/validator"
+    registry: "gcr.io"
+    repository: "prysmaticlabs/prysm/validator"
     tag: "v3.2.0"
   prysmGnosis:
-    repository: "ghcr.io/gnosischain/gbc-prysm-validator"
+    registry: "ghcr.io"
+    repository: "gnosischain/gbc-prysm-validator"
     tag: "v2.1.2-gbc"
   lighthouse:
+    registry: ""
     repository: "sigp/lighthouse"
     tag: "v3.4.0"
   teku:
+    registry: ""
     repository: "consensys/teku"
     tag: "23.1.0"
 

--- a/charts/web3signer/templates/statefulset.yaml
+++ b/charts/web3signer/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: init
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsUser: 0
@@ -54,7 +54,7 @@ spec:
             - name: data
               mountPath: /data
         - name: fetch-keys
-          image: "{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
+          image: "{{ .Values.cliImage.registry }}/{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
             runAsUser: 0
@@ -66,7 +66,7 @@ spec:
             - name: data
               mountPath: /data
         - name: migrations
-          image: "{{ .Values.flywayImage.repository }}:{{ .Values.flywayImage.tag }}"
+          image: "{{ .Values.flywayImage.registry }}/{{ .Values.flywayImage.repository }}:{{ .Values.flywayImage.tag }}"
           imagePullPolicy: {{ .Values.flywayImage.pullPolicy }}
           securityContext:
             runAsUser: 0
@@ -82,7 +82,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --config-file=/config/config.yaml

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -9,6 +9,7 @@ global:
 replicaCount: 3
 
 image:
+  registry: ""
   repository: consensys/web3signer
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
@@ -17,6 +18,7 @@ image:
 ## Init image is used to chown data volume, etc.
 ##
 initImage:
+  registry: ""
   repository: busybox
   tag: "1.34"
   pullPolicy: IfNotPresent
@@ -24,7 +26,8 @@ initImage:
 ## CLI image is used to fetch private keys.
 ##
 cliImage:
-  repository: europe-west4-docker.pkg.dev/stakewiselabs/public/cli
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/cli"
   tag: "v1.1.10"
   pullPolicy: IfNotPresent
 
@@ -39,6 +42,7 @@ decryptionKey: ""
 ## Flyawy image is used to apply database migrations
 ##
 flywayImage:
+  registry: ""
   repository: flyway/flyway
   tag: "8.5.8-alpine"
   pullPolicy: IfNotPresent

--- a/charts/whitelist/templates/statefulset.yaml
+++ b/charts/whitelist/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       {{- if and .Values.persistence.enabled .Values.initChownData }}
       initContainers:
         - name: init-chown
-          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          image: "{{ .Values.initImage.registry }}/{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
             runAsUser: 0
@@ -47,7 +47,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: DATABASE_PATH

--- a/charts/whitelist/values.yaml
+++ b/charts/whitelist/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: europe-west4-docker.pkg.dev/stakewiselabs/public/whitelist
+  registry: "europe-west4-docker.pkg.dev"
+  repository: "stakewiselabs/public/whitelist"
   pullPolicy: IfNotPresent
   ## Overrides the image tag whose default is the chart appVersion.
   ##
@@ -109,6 +110,7 @@ affinity: {}
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
+  registry: ""
   repository: "busybox"
   tag: "1.34"
   pullPolicy: IfNotPresent


### PR DESCRIPTION
# Summary

The image is always pulled from Docker Hub which means the actual image registry is set indirectly. The user should have the possibility to set the repository and registry separatly in order to pull images from different registries. This is especially important if a proxy registry like artifactory is used due to the fact that we need to overwrite the `repository` key and if you change the actual image repository things will break.

# Tested

Since this is a bigger change please test first on your side. Will also test on our side.

- [ ] StakeWise
- [ ] Our side