### PR TITLE
feat(graph): Make probes configurable

### DIFF
--- a/charts/graph-node/Chart.lock
+++ b/charts/graph-node/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.stakewise.io/
-  version: 1.0.0
+  version: 1.x.x
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami/
   version: 12.1.6
 - name: ipfs
   repository: https://charts.stakewise.io/
-  version: 1.1.1
-digest: sha256:56b74188213cf009c3b85d3da7dd6bc0aea5a6637f8158e503593f05ff6ecfa0
-generated: "2023-03-06T11:14:09.885118073+03:00"
+  version: 1.x.x
+digest: sha256:14c44427fcba160d41ef5a19a7e00a9373d0a18e8a9d04d53dbdbbefd98c6a14
+generated: "2023-04-06T09:44:24.890290951+03:00"

--- a/charts/graph-node/Chart.yaml
+++ b/charts/graph-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.3
+version: 2.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/graph-node/templates/statefulset.yaml
+++ b/charts/graph-node/templates/statefulset.yaml
@@ -75,11 +75,9 @@ spec:
             - name: metrics
               containerPort: {{ .Values.service.ports.metrics }}
               protocol: TCP
-          livenessProbe:
-            tcpSocket:
-              port: {{ .Values.service.ports.http }}
           readinessProbe:
-            tcpSocket:
-              port: {{ .Values.service.ports.http }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/graph-node/values.yaml
+++ b/charts/graph-node/values.yaml
@@ -224,3 +224,26 @@ prometheusRule:
   additionalLabels: {}
   # Custom Prometheus rules
   rules: []
+
+
+readinessProbe:
+  initialDelaySeconds: 60
+  timeoutSeconds: 1
+  periodSeconds: 10
+  failureThreshold: 3
+  successThreshold: 1
+  httpGet:
+    path: /
+    port: http
+    scheme: HTTP
+
+livenessProbe:
+  initialDelaySeconds: 60
+  timeoutSeconds: 1
+  periodSeconds: 10
+  failureThreshold: 3
+  successThreshold: 1
+  httpGet:
+    path: /
+    port: http
+    scheme: HTTP


### PR DESCRIPTION
- Change probe method from `tcpSocket` to `httpGet`
- Make probes as configurable values
- Increase `initialDelaySeconds` to 60sec