### PR TITLE
feat(statefulset): Add imagePullSecret and global serviceAccount variables

### DIFF
--- a/charts/ssv-node/templates/statefulset.yaml
+++ b/charts/ssv-node/templates/statefulset.yaml
@@ -31,6 +31,10 @@ spec:
       securityContext:
         {{ toYaml . | nindent 8 | trim }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml . | nindent 8 | trim }}
+      {{- end }}
       serviceAccountName: {{ include "common.names.serviceAccountName" . }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- if and .Values.persistence.enabled .Values.initChownData }}

--- a/charts/ssv-node/values.yaml
+++ b/charts/ssv-node/values.yaml
@@ -4,6 +4,10 @@
 
 replicaCount: 1
 
+global:
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:
@@ -31,8 +35,6 @@ registryContractAddr: 0x687fb596F3892904F879118e2113e1EEe8746C2E
 operatorPrivateKey: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.


### PR DESCRIPTION
The helm template could not be created without setting the global variable serviceAccount. Also the imagePullSecrets variable is not referenced in the statefulset