### PR TITLE
feat(service): Add variables for nodePort allocation and service type

### DIFF
--- a/charts/ssv-node/Chart.yaml
+++ b/charts/ssv-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ssv-node/templates/service.yaml
+++ b/charts/ssv-node/templates/service.yaml
@@ -11,6 +11,9 @@ spec:
       targetPort: discovery-tcp
       protocol: TCP
       name: discovery-tcp
+    {{- if and (eq .Values.service.type "NodePort") ( .Values.service.ports.discoveryTCP.nodePort ) }}
+      nodePort: {{ .Values.service.ports.discoveryTCP.nodePort }}
+    {{- end }}
   selector:
     {{- include "common.labels.matchLabels" . | nindent 4 }}
 ---
@@ -27,11 +30,14 @@ spec:
       targetPort: discovery-udp
       protocol: UDP
       name: discovery-udp
+      {{- if and (eq .Values.service.type "NodePort") ( .Values.service.ports.discoveryUDP.nodePort ) }}
+      nodePort: {{ .Values.service.ports.discoveryUDP.nodePort }}
+      {{- end }}
   selector:
     {{- include "common.labels.matchLabels" . | nindent 4 }}
 
 
-{{- if .Values.metrics.enabled  -}}
+{{ if .Values.metrics.enabled  -}}
 ---
 apiVersion: v1
 kind: Service
@@ -40,7 +46,7 @@ metadata:
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.metrics.service.type }}
   ports:
     - port: {{ .Values.metrics.metricsAPIPort }}
       targetPort: metrics-tcp

--- a/charts/ssv-node/values.yaml
+++ b/charts/ssv-node/values.yaml
@@ -47,6 +47,8 @@ metrics:
   ## Whether to enable metrics collection or not
   ##
   enabled: false
+  service:
+    type: ClusterIP
   metricsAPIPort: 15000
   ## Prometheus Service Monitor
   ## ref: https://github.com/coreos/prometheus-operator
@@ -76,6 +78,11 @@ securityContext:
 
 service:
   type: LoadBalancer
+  ports:
+    discoveryTCP:
+      nodePort: ""
+    discoveryUDP:
+      nodePort: ""
 
 ## Vertical Pod Autoscaler config
 ## Ref: https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler


### PR DESCRIPTION
Add the option to allocate nodeports to the services as well as change the metrics service type individually from the p2p services