### PR TITLE
Remove unsupported flag --ethash.dagdir

### DIFF
--- a/charts/geth/templates/statefulset.yaml
+++ b/charts/geth/templates/statefulset.yaml
@@ -138,7 +138,6 @@ spec:
               --override.terminaltotaldifficulty={{ .Values.terminalTotalDifficulty }}
           {{- end }}
               --datadir=/data/ethereum
-              --ethash.dagdir=/data/ethereum/.ethash
               --{{ .Values.global.network }}
           {{- range .Values.extraFlags }}
               {{ . | quote }}


### PR DESCRIPTION
Mining flag is no longer supported in 1.12.0 and the cli crashes.