### PR TITLE
feat(ipfs): Add servicemonitor to ipfs chart as well as adjust the va…

### DIFF
--- a/charts/ipfs/Chart.yaml
+++ b/charts/ipfs/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 2.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ipfs/templates/servicemonitor.yaml
+++ b/charts/ipfs/templates/servicemonitor.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: api
+      path: /debug/metrics/prometheus
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "common.labels.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/ipfs/values.yaml
+++ b/charts/ipfs/values.yaml
@@ -172,3 +172,31 @@ affinity: {}
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 ##
 priorityClassName: ""
+
+## Prometheus Service Monitor
+## ref: https://github.com/coreos/prometheus-operator
+##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+##
+serviceMonitor:
+  enabled: false
+  ## The namespace in which the ServiceMonitor will be created
+  ##
+  namespace: ""
+  ## The interval at which metrics should be scraped
+  ##
+  interval: 30s
+  ## The timeout after which the scrape is ended
+  ##
+  scrapeTimeout: ""
+  ## Metrics RelabelConfigs to apply to samples before scraping.
+  ##
+  relabelings: []
+  ## Metrics RelabelConfigs to apply to samples before ingestion.
+  ##
+  metricRelabelings: []
+  ## Specify honorLabels parameter to add the scrape endpoint
+  ##
+  honorLabels: false
+  ## Additional labels that can be used so ServiceMonitor resource(s) can be discovered by Prometheus
+  ##
+  additionalLabels: {}


### PR DESCRIPTION
Add a servicemonitor template to the ipfs node chart as well as adding the corresponding values to the values.yaml.
ipfs/kubo enables metrics per default under the api RPC port 5001 at /debug/metrics/prometheus