### PR TITLE
Add repo migration command

### DIFF
--- a/charts/ipfs/Chart.yaml
+++ b/charts/ipfs/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.3
+version: 2.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.19.1"
+appVersion: "v0.24.0"
 
 keywords:
   - ipfs

--- a/charts/ipfs/templates/entrypoint.yaml
+++ b/charts/ipfs/templates/entrypoint.yaml
@@ -24,6 +24,8 @@ data:
 
     if [ -e "$repo/config" ]; then
       echo "Found IPFS fs-repo at $repo"
+      echo "Try to migrate existing repo..."
+      ipfs repo migrate
     else
       case "$IPFS_PROFILE" in
         "") INIT_ARGS="" ;;


### PR DESCRIPTION
## Summary

This PR extends the entrypoint script for an ipfs repo migration. This is necessary since currently, if the repo version is upgraded, it is not possible to simply update the image. The start of the pod will fail. The chart user then needs to throw away the existing repo (pvc/pv) before he/she starts the pod so that the ipfs node is initiated with the latest repo version. This is suboptimal.