### PR TITLE
nethermind: adding secret name override

### DIFF
--- a/charts/nethermind/templates/statefulset.yaml
+++ b/charts/nethermind/templates/statefulset.yaml
@@ -114,7 +114,7 @@ spec:
               --JsonRpc.Port={{ .Values.jsonrpc.ports.rest }}
               --JsonRpc.WebSocketsPort={{ .Values.jsonrpc.ports.websocket }}
           {{- end }}
-          {{- if .Values.global.JWTSecret }}
+          {{- if or .Values.global.JWTSecret .Values.global.secretNameOverride }}
               --JsonRpc.JwtSecretFile=/secret/jwtsecret
               --JsonRpc.EnginePort={{ .Values.jsonrpc.engine.port }}
               --JsonRpc.EngineHost={{ .Values.jsonrpc.engine.host }}
@@ -160,7 +160,7 @@ spec:
               containerPort: {{ .Values.jsonrpc.ports.websocket }}
               protocol: TCP
           {{- end }}
-          {{- if .Values.global.JWTSecret }}
+          {{- if or .Values.global.JWTSecret .Values.global.secretNameOverride }}
             - name: engine
               protocol: TCP
               containerPort: {{ .Values.jsonrpc.engine.port }}
@@ -181,13 +181,16 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data/nethermind
-          {{- if .Values.global.JWTSecret }}
+          {{- if or .Values.global.JWTSecret .Values.global.secretNameOverride }}
             - name: jwtsecret
               mountPath: /secret
               readOnly: true
           {{- end }}
             - name: env-nodeport
               mountPath: /env
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if .Values.jsonrpc.enabled }}
@@ -199,11 +202,14 @@ spec:
               value: "{{ .Values.sidecar.bindAddr }}:{{ .Values.sidecar.bindPort }}"
             - name: CLIENT_PORT
               value: {{ .Values.jsonrpc.ports.rest | quote }}
-          {{- if .Values.global.JWTSecret }}
+          {{- if or .Values.global.JWTSecret .Values.global.secretNameOverride }}
             - name: CLIENT_AUTHORIZATIONTYPE
               value: "bearer"
             - name: CLIENT_JWTSECRET
-              value: {{ .Values.global.JWTSecret | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ coalesce .Values.global.secretNameOverride (include "common.names.fullname" .) }}
+                  key: jwtsecret
           {{- end }}
           ports:
             - containerPort: {{ .Values.sidecar.bindPort }}
@@ -235,10 +241,10 @@ spec:
         {{- end }}
       {{- end }}
       volumes:
-        {{- if .Values.global.JWTSecret }}
+        {{- if or .Values.global.JWTSecret .Values.global.secretNameOverride }}
         - name: jwtsecret
           secret:
-            secretName: {{ include "common.names.fullname" . }}
+            secretName: {{ coalesce .Values.global.secretNameOverride (include "common.names.fullname" .) }}
         {{- end }}
         - name: env-nodeport
           emptyDir: {}
@@ -246,6 +252,9 @@ spec:
         - name: data
           emptyDir: {}
 {{- else }}
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/nethermind/values.yaml
+++ b/charts/nethermind/values.yaml
@@ -16,6 +16,12 @@ global:
   ##
   JWTSecret: ""
 
+  ## If you would like the JSON Web Token (JWT) to be managed by a secert outside
+  ## of this chart, an existing secret name can be passed here. If specified, JWTSecret should not be set. 
+  ## jwtsecret should be the key of the token in the secret.
+  ##
+  secretNameOverride: ""
+
   ## Credentials to fetch images from private registry
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##
@@ -405,3 +411,25 @@ metrics:
     ## Custom Prometheus rules
     ##
     rules: []
+
+## Specify extra volumes which can be useful for for things like SecretProviderClass.
+## Useful if secretNameOverride is passed.
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+##
+extraVolumes: {}
+# - name: vault
+#   csi:
+#     driver: secrets-store.csi.k8s.io
+#     readOnly: true
+#     volumeAttributes:
+#       secretProviderClass: "nethermind"
+
+## Specify extra volume mounts which can be useful for things like SecretProviderClass.
+## Useful if secretNameOverride is passed.
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+##
+extraVolumeMounts: {}
+# An example is listed below on how to specify an extra volume mount using SecretProviderClass
+# - name: 'vault'
+#   mountPath: '/mnt/secrets-store'
+#   readOnly: true


### PR DESCRIPTION
Big fan of this repo!

The current way secrets are handled in this repo is not the most ideal in my opinion. While the [docs](https://docs.stakewise.io/for-operators/kubernetes-staking-setup#step-2.-configuring-the-execution-node) show an example of specifying the JWT token via an environment variable (which is not bad security wise), if one wanted to track their `values.yaml` file in git, the current chart requires `.Values.global.JWTSecret` to be tracked in code. 

Additionally, it's very common for people to use external secret providers like Hashicorp Vault (which I have seen Stakewise supports in some areas already). To do this, one could use a [SecretProviderClass](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/usage) (or the vault injector obviously).

This PR allows for:

- The chart to reference a secret that is not managed by the chart
- Adding additional volumes
- Adding additional volumeMounts