### PR TITLE
feat(geth): add conditional logic for network and networkid

### DIFF
--- a/charts/geth/templates/statefulset.yaml
+++ b/charts/geth/templates/statefulset.yaml
@@ -138,7 +138,11 @@ spec:
               --override.terminaltotaldifficulty={{ .Values.terminalTotalDifficulty }}
           {{- end }}
               --datadir=/data/ethereum
+          {{- if .Values.global.network }}
               --{{ .Values.global.network }}
+          {{- else }}
+              --networkid {{ .Values.global.networkid }}
+          {{- end }}
           {{- range .Values.extraFlags }}
               {{ . | quote }}
           {{- end }}

--- a/charts/geth/values.yaml
+++ b/charts/geth/values.yaml
@@ -6,8 +6,19 @@ global:
   replicaCount: 1
 
   ## Eth2 network ID
+  ## Use one of the predefined testnets or mainnet:
+  ## - mainnet (default)
+  ## - goerli
+  ## - sepolia
+  ## - holesky
+  ##
+  ## If using a custom network, comment out 'network' and set 'networkid' instead.
   ##
   network: mainnet
+
+  ## Custom network ID for private or other networks.
+  ## Only set this if 'network' is not defined.
+  # networkid: 100
 
   ## JSON Web Token (JWT) authentication is used to secure the communication
   ## between the beacon node and execution client. You can generate a JWT using


### PR DESCRIPTION
Based on Geth documentation: `--goerli`, `--holesky`, `--mainnet`, and `--sepolia` are predefined networks, while `--networkid` is used for custom or other networks