### PR TITLE
Add hoodi support for mev boost

### DIFF
--- a/charts/mev-boost/Chart.yaml
+++ b/charts/mev-boost/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.2
+version: 1.7.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mev-boost/templates/validate.yaml
+++ b/charts/mev-boost/templates/validate.yaml
@@ -1,0 +1,38 @@
+{{- /*
+This template validates that if network is "hoodi", the image tag must be greater than or equal to 1.9.0 or 1.9-rc3 respectively.
+*/ -}}
+
+{{- $network := .Values.global.network }}
+{{- $imageTag := .Values.image.tag }}
+
+{{- /* Define a function to normalize version strings */ -}}
+{{- define "semverCompare" -}}
+{{- /* This helper normalizes version strings for comparison */ -}}
+{{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+$" . -}}
+  {{- /* It's a full semver (e.g., 1.9.0) */ -}}
+  {{- . -}}
+{{- else if regexMatch "^[0-9]+\\.[0-9]+$" . -}}
+  {{- /* It's a short version (e.g., 1.9) - convert to 1.9.0 */ -}}
+  {{- printf "%s.0" . -}}
+{{- else if regexMatch "^[0-9]+\\.[0-9]+-rc[0-9]+$" . -}}
+  {{- /* It's a semver with rc suffix (format: 1.9-rc3) */ -}}
+  {{- . -}}
+{{- else -}}
+  {{- /* It's something else */ -}}
+  {{- . -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* Check if we need to validate (only for "hoodi" network) */ -}}
+{{- if eq $network "hoodi" -}}
+  {{- /* Transform the tag for comparison */ -}}
+  {{- $normalizedTag := include "semverCompare" $imageTag -}}
+  
+  {{- /* Debug - uncomment if needed */}}
+  {{- /* fail (printf "DEBUG: Original tag: %s, Normalized: %s" $imageTag $normalizedTag) */}}
+
+  {{- /* Perform the validation checks */ -}}
+  {{- if or (semverCompare "< 1.9.0" $normalizedTag) (semverCompare "< 1.9-rc3" $normalizedTag) -}}
+    {{- fail "ERROR: For network 'hoodi', image tag must be at least '1.9.0' or '1.9-rc3'" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/mev-boost/values.yaml
+++ b/charts/mev-boost/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 global:
-  # Options: mainnet, holesky, ropsten, kiln, sepolia
+  # Options: mainnet, holesky, sepolia, hoodi
   network: "mainnet"
 
   ## Credentials to fetch images from private registry
@@ -18,9 +18,8 @@ global:
 relays:
   mainnet: "https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net"
   holesky: "https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-holesky.flashbots.net"
-  ropsten: "https://0xb124d80a00b80815397b4e7f1f05377ccc83aeeceb6be87963ba3649f1e6efa32ca870a88845917ec3f26a8e2aa25c77@builder-relay-ropsten.flashbots.net"
-  kiln: "https://0xb5246e299aeb782fbc7c91b41b3284245b1ed5206134b0028b81dfb974e5900616c67847c2354479934fc4bb75519ee1@builder-relay-kiln.flashbots.net"
   sepolia: "https://0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a@builder-relay-sepolia.flashbots.net"
+  hoodi: "https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-hoodi.flashbots.net"
 
 # minimum loglevel: trace, debug, info, warn/warning, error, fatal, panic
 logLevel: info


### PR DESCRIPTION
## Summary

This PR:

* adds hoodi support for mev-boost
* deletes deprecated ethereum testnets

Note, I added a validation template which checks that the image tag is sufficient for hoodi usage. This way we can stay at latest stable release version (`1.8.0`) but the user is able to use it with hoodi while overwriting to a proper release candidate version (>= rc3).