### PR TITLE
feat: load keys from HashiCorp Vault

### DIFF
--- a/charts/v3-operator/README.md
+++ b/charts/v3-operator/README.md
@@ -22,6 +22,9 @@ Kubernetes secrets are used to store sensitive information related to the v3-ope
 kubectl create secret generic v3-operator-deposit-data --from-file=/home/username/.stakewise/0xeefffd4c23d2e8c845870e273861e7d60df49663/deposit_data.json
 kubectl create secret generic v3-operator-keystores-data --from-file=/home/username/.stakewise/0xeefffd4c23d2e8c845870e273861e7d60df49663/keystores
 kubectl create secret generic v3-operator-wallet-data --from-file=/home/username/.stakewise/0xeefffd4c23d2e8c845870e273861e7d60df49663/wallet
+
+# optional if you are using HashiCorp Vault
+kubectl create secret generic v3-operator-hcv-token --from-literal=token=<insert token here>
 ```
 
 > Replace `0xeefffd4c23d2e8c845870e273861e7d60df49663` with the actual vault contract address

--- a/charts/v3-operator/templates/statefulset.yaml
+++ b/charts/v3-operator/templates/statefulset.yaml
@@ -94,12 +94,25 @@ spec:
             - --remote-signer-url
             - {{ .Values.settings.remoteDbConfig.remoteSignerUrl }}
           {{- end }}
+          {{- if .Values.settings.hcVaultConfig.enabled }}
+            - --hashi-vault-url
+            - {{ .Values.settings.hcVaultConfig.hcVaultUrl }}
+            - --hashi-vault-token
+            - $(HASHICORP_VAULT_TOKEN)
+            - --hashi-vault-key-path
+            - {{ .Values.settings.hcVaultConfig.hcVaultKeyPath }}
+          {{- end }}
           {{- range .Values.settings.extraFlags }}
             - {{ . }}
           {{- end }}
           env:
             - name: PYTHONPATH
               value: "."
+            - name: HASHICORP_VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.settings.hcVaultConfig.hcVaultTokenSecretName }}
+                  key: token
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" . }}

--- a/charts/v3-operator/templates/validate.yaml
+++ b/charts/v3-operator/templates/validate.yaml
@@ -9,3 +9,9 @@
 {{- if not .Values.settings.vault }}
 {{- fail ".Values.settings.vault is empty" }}
 {{- end }}
+
+{{- if .Values.settings.hcVaultConfig.enabled -}}
+{{- if not .Values.settings.hcVaultConfig.hcVaultTokenSecretName }}
+{{- fail ".Values.settings.hcVaultConfig.hcVaultTokenSecretName is empty" }}
+{{- end }}
+{{- end }}

--- a/charts/v3-operator/values.yaml
+++ b/charts/v3-operator/values.yaml
@@ -105,6 +105,13 @@ settings:
     dbUrl: "postgresql://postgres:postgres@localhost/operator"
     remoteSignerUrl: "http://web3signer:6174"
 
+  # Whether to receive keystores from HashiCorp Vault
+  hcVaultConfig:
+    enabled: false
+    hcVaultUrl: "http://vault:8200"
+    hcVaultTokenSecretName: ""
+    hcVaultKeyPath: "stakewise"
+
   # If specified, deposit data will be obtained from the secret
   depositDataSecretName: ""
   # If specified, keystores will be obtained from the secret

--- a/charts/v3-operator/values.yaml
+++ b/charts/v3-operator/values.yaml
@@ -57,7 +57,7 @@ serviceAccount:
 image:
   registry: "europe-west4-docker.pkg.dev"
   repository: "stakewiselabs/public/v3-operator"
-  tag: "v3.0.3"
+  tag: "v3.1.8"
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Adds a new `hcVaultConfig` settings block to enable the operator to load the keys from an HashiCorp vault