### PR TITLE
Fix helm syntax errors for v3-oracle

### DIFF
--- a/charts/v3-oracle/Chart.yaml
+++ b/charts/v3-oracle/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: v3-oracle
-version: 3.5.3
+version: 3.5.4
 appVersion: v3.1.7
 kubeVersion: "^1.14.0-0"
 description: The StakeWise application for submitting off-chain data to smart contracts.

--- a/charts/v3-oracle/templates/configmap.yaml
+++ b/charts/v3-oracle/templates/configmap.yaml
@@ -27,27 +27,27 @@ data:
   {{- if .Values.settings.executionGraphqlEndpoint }}
   EXECUTION_GRAPHQL_ENDPOINT: {{ .Values.settings.executionGraphqlEndpoint | quote }}
   {{- end }}
-  {{ - if .Values.settings.validatorsFetchChunkSize }}
+  {{- if .Values.settings.validatorsFetchChunkSize }}
   VALIDATORS_FETCH_CHUNK_SIZE: {{ .Values.settings.validatorsFetchChunkSize | quote }}
-  {{ - end }}
-  {{ - if .Values.settings.validatorsWithdrawalsChunkSize }}
+  {{- end }}
+  {{- if .Values.settings.validatorsWithdrawalsChunkSize }}
   VALIDATORS_WITHDRAWALS_CHUNK_SIZE: {{ .Values.settings.validatorsWithdrawalsChunkSize | quote }}
-  {{ - end }}
-  {{ - if .Values.settings.validatorsWithdrawalsConcurrency }}
+  {{- end }}
+  {{- if .Values.settings.validatorsWithdrawalsConcurrency }}
   VALIDATORS_WITHDRAWALS_CONCURRENCY: {{ .Values.settings.validatorsWithdrawalsConcurrency | quote }}
-  {{ - end }}
-  {{ - if .Values.settings.defaultRetryTime }}
+  {{- end }}
+  {{- if .Values.settings.defaultRetryTime }}
   DEFAULT_RETRY_TIME: {{ .Values.settings.defaultRetryTime | quote }}
-  {{ - end }}
-  {{ - if .Values.settings.consensusBlockChunkSize }}
+  {{- end }}
+  {{- if .Values.settings.consensusBlockChunkSize }}
   CONSENSUS_BLOCK_CHUNK_SIZE: {{ .Values.settings.consensusBlockChunkSize | quote }}
-  {{ - end }}
-  {{ - if .Values.settings.consensusBlockConcurrency }}
+  {{- end }}
+  {{- if .Values.settings.consensusBlockConcurrency }}
   CONSENSUS_BLOCK_CONCURRENCY: {{ .Values.settings.consensusBlockConcurrency | quote }}
-  {{ - end }}
-  {{ - if .Values.settings.eventsBlockRangeInterval }}
+  {{- end }}
+  {{- if .Values.settings.eventsBlockRangeInterval }}
   EVENTS_BLOCKS_RANGE_INTERVAL: {{ .Values.settings.eventsBlockRangeInterval | quote }}
-  {{ - end }}
+  {{- end }}
   METRICS_ENABLED: {{ .Values.settings.metricsEnabled | quote }}
   HEALTHZ_ENABLED: {{ .Values.settings.healthzEnabled | quote }}
   {{- if .Values.settings.subgraphEndpoints }}


### PR DESCRIPTION
## Summary

Some syntax errors were introduced in the configmap while deleting default values for the v3-oracle env variables. This PR fixes the errors.

### Example error

```
Error: parse error at (v3-oracle/templates/configmap.yaml:30): "-"
```